### PR TITLE
feat: document references and backlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ test-vault/
 !.well-known
 !.gitignore
 docs/plans/
+.claude/worktrees/

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import { prepareNoteForPublish, extractRkeyFromUri } from "./publish";
 import { computeSyncDiff, type VaultNote, type PdsRecord } from "./sync";
 import { deriveDocumentPath } from "./paths";
 import type { NoteFrontmatter } from "./types";
+import type { WikilinkResolver, ResolvedWikilink } from "./transform";
 import { buildNoteFromRecord } from "./pull";
 
 export default class StandardSitePlugin extends Plugin {
@@ -111,8 +112,8 @@ export default class StandardSitePlugin extends Plugin {
 		throw new Error("Please select a publication in settings");
 	}
 
-	private buildWikilinkResolver(): (target: string) => string | null {
-		return (target: string) => {
+	private buildWikilinkResolver(did: string): WikilinkResolver {
+		return (target: string): ResolvedWikilink | null => {
 			const destFile = this.app.metadataCache.getFirstLinkpathDest(target, "");
 			if (!destFile) return null;
 
@@ -120,7 +121,12 @@ export default class StandardSitePlugin extends Plugin {
 			const frontmatter = cache?.frontmatter as NoteFrontmatter | undefined;
 			if (!frontmatter?.publish) return null;
 
-			return deriveDocumentPath(destFile.path, this.settings.publishRoot, frontmatter.slug);
+			const path = deriveDocumentPath(destFile.path, this.settings.publishRoot, frontmatter.slug);
+			const uri = frontmatter.rkey
+				? `at://${did}/site.standard.document/${frontmatter.rkey}`
+				: undefined;
+
+			return { path, uri };
 		};
 	}
 
@@ -155,7 +161,7 @@ export default class StandardSitePlugin extends Plugin {
 				frontmatter,
 				body,
 				config: { siteUri, publishRoot: this.settings.publishRoot },
-				resolveWikilink: this.buildWikilinkResolver(),
+				resolveWikilink: this.buildWikilinkResolver(client.did),
 				existingPublishedAt,
 			});
 
@@ -239,7 +245,7 @@ export default class StandardSitePlugin extends Plugin {
 						frontmatter,
 						body,
 						config: { siteUri, publishRoot: this.settings.publishRoot },
-						resolveWikilink: this.buildWikilinkResolver(),
+						resolveWikilink: this.buildWikilinkResolver(client.did),
 						existingPublishedAt,
 					});
 

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -34,7 +34,7 @@ export function prepareNoteForPublish(input: PrepareInput): PrepareResult {
 	const path = deriveDocumentPath(filePath, config.publishRoot, frontmatter.slug);
 
 	// Transform markdown
-	const transformedMarkdown = transformObsidianMarkdown(body, resolveWikilink);
+	const { text: transformedMarkdown, references } = transformObsidianMarkdown(body, resolveWikilink);
 
 	// Extract plain text from transformed markdown
 	const plainText = markdownToPlainText(transformedMarkdown);
@@ -55,6 +55,7 @@ export function prepareNoteForPublish(input: PrepareInput): PrepareResult {
 		updatedAt,
 		markdown: transformedMarkdown,
 		plainText,
+		references,
 	});
 
 	return {

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,37 +1,40 @@
-export type WikilinkResolver = (target: string) => string | null;
+export interface ResolvedWikilink {
+	path: string;
+	uri?: string;
+}
+
+export type WikilinkResolver = (target: string) => ResolvedWikilink | null;
+
+export interface TransformResult {
+	text: string;
+	references: Array<{ uri: string }>;
+}
 
 export function transformObsidianMarkdown(
 	markdown: string,
 	resolveWikilink: WikilinkResolver
-): string {
+): TransformResult {
 	let result = markdown;
+	const references: Array<{ uri: string }> = [];
 
-	// Remove multiline comments: %%\n...\n%%
 	result = result.replace(/%%\n[\s\S]*?\n%%/g, "");
-
-	// Remove inline comments: %%...%%
 	result = result.replace(/%%.*?%%/g, "");
-
-	// Convert highlights: ==text== → <mark>text</mark>
 	result = result.replace(/==(.*?)==/g, "<mark>$1</mark>");
-
-	// Remove embeds: ![[...]] (whole line if alone, inline otherwise)
 	result = result.replace(/!\[\[.*?\]\]/g, "");
-
-	// Convert callouts: > [!type] Title → > **Title**
 	result = result.replace(/^(>\s*)\[!(\w+)\][^\S\n]*(.*)/gm, (_match, prefix, _type, title) => {
 		return title ? `${prefix}**${title}**` : `${prefix}`;
 	});
-
-	// Resolve wikilinks: [[target|display]] or [[target]]
 	result = result.replace(/\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g, (_match, target, display) => {
-		const resolvedPath = resolveWikilink(target);
+		const resolved = resolveWikilink(target);
 		const text = display || target.split("/").pop() || target;
-		if (resolvedPath) {
-			return `[${text}](${resolvedPath})`;
+		if (resolved) {
+			if (resolved.uri) {
+				references.push({ uri: resolved.uri });
+			}
+			return `[${text}](${resolved.path})`;
 		}
 		return text;
 	});
 
-	return result;
+	return { text: result, references };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ export interface DocumentRecord {
 	content?: MarkpubMarkdown;
 	coverImage?: unknown;
 	bskyPostRef?: unknown;
+	references?: Array<{ uri: string }>;
 }
 
 export interface PublicationRecord {
@@ -52,6 +53,7 @@ export interface DocumentInput {
 	updatedAt?: string;
 	markdown: string;
 	plainText: string;
+	references?: Array<{ uri: string }>;
 }
 
 export function buildDocumentRecord(input: DocumentInput): DocumentRecord {
@@ -77,6 +79,9 @@ export function buildDocumentRecord(input: DocumentInput): DocumentRecord {
 	}
 	if (input.updatedAt) {
 		record.updatedAt = input.updatedAt;
+	}
+	if (input.references && input.references.length > 0) {
+		record.references = input.references;
 	}
 
 	return record;

--- a/tests/publish.test.ts
+++ b/tests/publish.test.ts
@@ -7,7 +7,7 @@ describe("prepareNoteForPublish", () => {
 		publishRoot: "",
 	};
 
-	const noopResolver = (_target: string) => null;
+	const noopResolver = (_target: string): import("../src/transform").ResolvedWikilink | null => null;
 
 	it("prepares a complete document record from note data", () => {
 		const result = prepareNoteForPublish({
@@ -86,6 +86,37 @@ describe("prepareNoteForPublish", () => {
 
 		expect(result.record.publishedAt).toBe("2026-01-01T00:00:00.000Z");
 		expect(result.record.updatedAt).toBeDefined();
+	});
+
+	it("includes references from resolved wikilinks with URIs", () => {
+		const resolver = (target: string): import("../src/transform").ResolvedWikilink | null => {
+			if (target === "Other Post") return { path: "/other-post", uri: "at://did:plc:abc123/site.standard.document/xyz" };
+			return null;
+		};
+
+		const result = prepareNoteForPublish({
+			filePath: "post.md",
+			frontmatter: { title: "Post", publish: true },
+			body: "See [[Other Post]]",
+			config: defaultConfig,
+			resolveWikilink: resolver,
+		});
+
+		expect(result.record.references).toEqual([
+			{ uri: "at://did:plc:abc123/site.standard.document/xyz" },
+		]);
+	});
+
+	it("omits references when no wikilinks have URIs", () => {
+		const result = prepareNoteForPublish({
+			filePath: "post.md",
+			frontmatter: { title: "Post", publish: true },
+			body: "No links here",
+			config: defaultConfig,
+			resolveWikilink: noopResolver,
+		});
+
+		expect(result.record.references).toBeUndefined();
 	});
 
 	it("indicates create vs update based on rkey presence", () => {

--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -1,129 +1,141 @@
 import { describe, it, expect } from "vitest";
-import { transformObsidianMarkdown } from "../src/transform";
+import { transformObsidianMarkdown, type ResolvedWikilink } from "../src/transform";
 
-// The resolveWikilink callback: given a link target, returns the published
-// path if the note is published, or null if not.
 const noopResolver = (_target: string) => null;
 
 describe("transformObsidianMarkdown", () => {
 	describe("comments", () => {
 		it("removes Obsidian comments", () => {
 			const input = "Before %%secret comment%% after";
-			expect(transformObsidianMarkdown(input, noopResolver)).toBe("Before  after");
+			expect(transformObsidianMarkdown(input, noopResolver).text).toBe("Before  after");
 		});
-
 		it("removes multiline comments", () => {
 			const input = "Before\n%%\nmultiline\ncomment\n%%\nafter";
-			expect(transformObsidianMarkdown(input, noopResolver)).toBe("Before\n\nafter");
+			expect(transformObsidianMarkdown(input, noopResolver).text).toBe("Before\n\nafter");
 		});
 	});
 
 	describe("highlights", () => {
 		it("converts highlights to <mark> tags", () => {
 			const input = "This is ==highlighted== text";
-			expect(transformObsidianMarkdown(input, noopResolver)).toBe(
-				"This is <mark>highlighted</mark> text"
-			);
+			expect(transformObsidianMarkdown(input, noopResolver).text).toBe("This is <mark>highlighted</mark> text");
 		});
-
 		it("handles multiple highlights", () => {
 			const input = "==one== and ==two==";
-			expect(transformObsidianMarkdown(input, noopResolver)).toBe(
-				"<mark>one</mark> and <mark>two</mark>"
-			);
+			expect(transformObsidianMarkdown(input, noopResolver).text).toBe("<mark>one</mark> and <mark>two</mark>");
 		});
 	});
 
 	describe("embeds", () => {
 		it("removes image embeds", () => {
 			const input = "Before\n![[image.png]]\nafter";
-			expect(transformObsidianMarkdown(input, noopResolver)).toBe("Before\n\nafter");
+			expect(transformObsidianMarkdown(input, noopResolver).text).toBe("Before\n\nafter");
 		});
-
 		it("removes embeds with alt text", () => {
 			const input = "Before\n![[document.pdf|My PDF]]\nafter";
-			expect(transformObsidianMarkdown(input, noopResolver)).toBe("Before\n\nafter");
+			expect(transformObsidianMarkdown(input, noopResolver).text).toBe("Before\n\nafter");
 		});
 	});
 
 	describe("callouts", () => {
 		it("converts callouts to plain blockquotes", () => {
 			const input = "> [!note] Title\n> Content here";
-			expect(transformObsidianMarkdown(input, noopResolver)).toBe(
-				"> **Title**\n> Content here"
-			);
+			expect(transformObsidianMarkdown(input, noopResolver).text).toBe("> **Title**\n> Content here");
 		});
-
 		it("converts callouts without title", () => {
 			const input = "> [!warning]\n> Be careful";
-			expect(transformObsidianMarkdown(input, noopResolver)).toBe(
-				"> \n> Be careful"
-			);
+			expect(transformObsidianMarkdown(input, noopResolver).text).toBe("> \n> Be careful");
 		});
 	});
 
 	describe("passthrough", () => {
 		it("preserves standard markdown", () => {
 			const input = "# Heading\n\n**bold** and *italic*\n\n- list item\n\n```js\ncode\n```";
-			expect(transformObsidianMarkdown(input, noopResolver)).toBe(input);
+			expect(transformObsidianMarkdown(input, noopResolver).text).toBe(input);
 		});
-
 		it("preserves GFM tables", () => {
 			const input = "| a | b |\n|---|---|\n| 1 | 2 |";
-			expect(transformObsidianMarkdown(input, noopResolver)).toBe(input);
+			expect(transformObsidianMarkdown(input, noopResolver).text).toBe(input);
 		});
-
 		it("preserves standard links", () => {
 			const input = "[text](https://example.com)";
-			expect(transformObsidianMarkdown(input, noopResolver)).toBe(input);
+			expect(transformObsidianMarkdown(input, noopResolver).text).toBe(input);
 		});
 	});
 
 	describe("wikilinks", () => {
-		const resolver = (target: string) => {
-			const published: Record<string, string> = {
-				"My Other Post": "/blog/my-other-post",
-				"recipes/Pasta": "/recipes/pasta",
+		const resolver = (target: string): ResolvedWikilink | null => {
+			const published: Record<string, ResolvedWikilink> = {
+				"My Other Post": { path: "/blog/my-other-post" },
+				"recipes/Pasta": { path: "/recipes/pasta" },
 			};
 			return published[target] ?? null;
 		};
 
 		it("resolves published wikilinks to markdown links", () => {
 			const input = "Check out [[My Other Post]]";
-			expect(transformObsidianMarkdown(input, resolver)).toBe(
-				"Check out [My Other Post](/blog/my-other-post)"
-			);
+			expect(transformObsidianMarkdown(input, resolver).text).toBe("Check out [My Other Post](/blog/my-other-post)");
 		});
-
 		it("resolves wikilinks with display text", () => {
 			const input = "Check out [[My Other Post|this post]]";
-			expect(transformObsidianMarkdown(input, resolver)).toBe(
-				"Check out [this post](/blog/my-other-post)"
-			);
+			expect(transformObsidianMarkdown(input, resolver).text).toBe("Check out [this post](/blog/my-other-post)");
 		});
-
 		it("converts unpublished wikilinks to plain text", () => {
 			const input = "See [[Unpublished Draft]]";
-			expect(transformObsidianMarkdown(input, resolver)).toBe("See Unpublished Draft");
+			expect(transformObsidianMarkdown(input, resolver).text).toBe("See Unpublished Draft");
 		});
-
 		it("converts unpublished wikilinks with display text to plain text", () => {
 			const input = "See [[Unpublished Draft|my draft]]";
-			expect(transformObsidianMarkdown(input, resolver)).toBe("See my draft");
+			expect(transformObsidianMarkdown(input, resolver).text).toBe("See my draft");
 		});
-
 		it("resolves subpath wikilinks", () => {
 			const input = "Make [[recipes/Pasta]]";
-			expect(transformObsidianMarkdown(input, resolver)).toBe(
-				"Make [Pasta](/recipes/pasta)"
-			);
+			expect(transformObsidianMarkdown(input, resolver).text).toBe("Make [Pasta](/recipes/pasta)");
 		});
-
 		it("handles multiple wikilinks in one line", () => {
 			const input = "[[My Other Post]] and [[Unpublished Draft]]";
-			expect(transformObsidianMarkdown(input, resolver)).toBe(
-				"[My Other Post](/blog/my-other-post) and Unpublished Draft"
-			);
+			expect(transformObsidianMarkdown(input, resolver).text).toBe("[My Other Post](/blog/my-other-post) and Unpublished Draft");
+		});
+	});
+
+	describe("references", () => {
+		it("returns empty references when no wikilinks have URIs", () => {
+			const resolver = (target: string): ResolvedWikilink | null => {
+				if (target === "My Post") return { path: "/my-post" };
+				return null;
+			};
+			const result = transformObsidianMarkdown("See [[My Post]]", resolver);
+			expect(result.references).toEqual([]);
+		});
+		it("collects references from resolved wikilinks with URIs", () => {
+			const resolver = (target: string): ResolvedWikilink | null => {
+				if (target === "My Post") return { path: "/my-post", uri: "at://did:plc:abc/site.standard.document/xyz" };
+				return null;
+			};
+			const result = transformObsidianMarkdown("See [[My Post]]", resolver);
+			expect(result.references).toEqual([{ uri: "at://did:plc:abc/site.standard.document/xyz" }]);
+		});
+		it("collects multiple references", () => {
+			const resolver = (target: string): ResolvedWikilink | null => {
+				const map: Record<string, ResolvedWikilink> = {
+					"Post A": { path: "/post-a", uri: "at://did:plc:abc/site.standard.document/aaa" },
+					"Post B": { path: "/post-b", uri: "at://did:plc:abc/site.standard.document/bbb" },
+				};
+				return map[target] ?? null;
+			};
+			const result = transformObsidianMarkdown("[[Post A]] and [[Post B]]", resolver);
+			expect(result.references).toEqual([
+				{ uri: "at://did:plc:abc/site.standard.document/aaa" },
+				{ uri: "at://did:plc:abc/site.standard.document/bbb" },
+			]);
+		});
+		it("does not collect references for unresolved wikilinks", () => {
+			const result = transformObsidianMarkdown("[[Unknown]]", noopResolver);
+			expect(result.references).toEqual([]);
+		});
+		it("returns empty references when no wikilinks present", () => {
+			const result = transformObsidianMarkdown("No links here", noopResolver);
+			expect(result.references).toEqual([]);
 		});
 	});
 });

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -62,4 +62,51 @@ describe("buildDocumentRecord", () => {
 
 		expect(record.updatedAt).toBe("2026-02-27T12:00:00.000Z");
 	});
+
+	it("includes references when provided", () => {
+		const record = buildDocumentRecord({
+			siteUri: "at://did:plc:abc123/site.standard.publication/self",
+			title: "Post with refs",
+			path: "/refs",
+			publishedAt: "2026-02-26T12:00:00.000Z",
+			markdown: "Content",
+			plainText: "Content",
+			references: [
+				{ uri: "at://did:plc:abc/site.standard.document/aaa" },
+				{ uri: "at://did:plc:abc/site.standard.document/bbb" },
+			],
+		});
+
+		expect(record.references).toEqual([
+			{ uri: "at://did:plc:abc/site.standard.document/aaa" },
+			{ uri: "at://did:plc:abc/site.standard.document/bbb" },
+		]);
+	});
+
+	it("omits references when empty array", () => {
+		const record = buildDocumentRecord({
+			siteUri: "at://did:plc:abc123/site.standard.publication/self",
+			title: "No refs",
+			path: "/no-refs",
+			publishedAt: "2026-02-26T12:00:00.000Z",
+			markdown: "Content",
+			plainText: "Content",
+			references: [],
+		});
+
+		expect(record.references).toBeUndefined();
+	});
+
+	it("omits references when not provided", () => {
+		const record = buildDocumentRecord({
+			siteUri: "at://did:plc:abc123/site.standard.publication/self",
+			title: "No refs",
+			path: "/no-refs",
+			publishedAt: "2026-02-26T12:00:00.000Z",
+			markdown: "Content",
+			plainText: "Content",
+		});
+
+		expect(record.references).toBeUndefined();
+	});
 });

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -239,6 +239,32 @@ body {
 }
 .site-footer a { color: var(--link); text-decoration: none; }
 .site-footer a:hover { text-decoration: underline; }
+
+/* Backlinks */
+.backlinks {
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border);
+}
+.backlinks h2 {
+  font-size: 1rem;
+  color: var(--text-secondary);
+  margin-bottom: 0.5rem;
+}
+.backlinks ul {
+  list-style: none;
+  padding: 0;
+}
+.backlinks li {
+  padding: 0.3rem 0;
+}
+.backlinks a {
+  color: var(--link);
+  text-decoration: none;
+}
+.backlinks a:hover {
+  text-decoration: underline;
+}
 </style>
 </head>
 <body>
@@ -609,7 +635,16 @@ function showHomepage(publication, documents, did) {
   app.appendChild(renderFooter());
 }
 
-function showPost(publication, doc, did) {
+function findBacklinks(targetUri, documents) {
+  if (!targetUri) return [];
+  return documents.filter((d) => {
+    const refs = d.value.references;
+    if (!refs || !Array.isArray(refs)) return false;
+    return refs.some((r) => r.uri === targetUri);
+  });
+}
+
+function showPost(publication, doc, did, documents) {
   const app = clearApp();
   const v = doc.value;
   const rkey = extractRkey(doc.uri);
@@ -647,6 +682,24 @@ function showPost(publication, doc, did) {
     contentDiv.appendChild(p);
   }
   article.appendChild(contentDiv);
+
+  // Backlinks
+  const targetUri = `at://${did}/site.standard.document/${rkey}`;
+  const backlinks = findBacklinks(targetUri, documents || []);
+  if (backlinks.length > 0) {
+    const backlinksSection = el("section", { className: "backlinks" });
+    backlinksSection.appendChild(el("h2", null, "Backlinks"));
+    const ul = el("ul");
+    for (const bl of backlinks) {
+      const blRkey = extractRkey(bl.uri);
+      const href = "#" + (bl.value.path || "/" + blRkey);
+      const li = el("li");
+      li.appendChild(el("a", { href }, bl.value.title || "Untitled"));
+      ul.appendChild(li);
+    }
+    backlinksSection.appendChild(ul);
+    article.appendChild(backlinksSection);
+  }
 
   app.appendChild(article);
   app.appendChild(renderFooter());
@@ -717,7 +770,7 @@ function render() {
   if (route.type === "post") {
     const doc = findDocument(documents, route.path);
     if (doc) {
-      showPost(publication, doc, did);
+      showPost(publication, doc, did, documents);
     } else {
       showNotFound(route.path);
     }


### PR DESCRIPTION
## Summary
- Refactor `WikilinkResolver` to return `ResolvedWikilink` objects with optional AT-URI
- `transformObsidianMarkdown` now returns `TransformResult` with `text` and `references` array
- Thread references through `DocumentInput` → `buildDocumentRecord` → `DocumentRecord`
- Update `buildWikilinkResolver` in main.ts to construct AT-URIs from published note rkeys
- Add backlinks section to viewer that finds documents referencing the current document

## Test plan
- [x] 77 tests passing (5 new reference tests in transform, 5 new in types/publish)
- [x] Manual test: publish two notes with wikilinks between them, verify references in ATProto records
- [x] Manual test: verify backlinks section appears in viewer when documents reference each other

🤖 Generated with [Claude Code](https://claude.com/claude-code)