### PR TITLE
feat: social cards & History API routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ Host the resulting directory on any static host (GitHub Pages, Cloudflare Pages,
 
 ### Features
 
-- Client-side rendering with hash-based routing
+- Client-side rendering with clean URL routing (History API)
+- Open Graph and Twitter Card meta tags for social sharing
 - Light/dark mode
 - Post list with dates, descriptions, tags, and cover image thumbnails
 - Cover images displayed as hero images on individual posts
@@ -102,6 +103,17 @@ Host the resulting directory on any static host (GitHub Pages, Cloudflare Pages,
 - Inter-note link resolution
 - Custom theming via `custom.css`
 - 5-minute session cache with manual refresh
+- Optional Cloudflare Pages Function for per-post social cards
+
+### Deployment
+
+The viewer works on any static host. For enhanced social sharing (per-post cards when links are shared on Twitter, Discord, etc.), deploy to Cloudflare Pages — the included Pages Function automatically injects Open Graph meta tags by fetching your content from ATProto at the edge.
+
+| Host | Social cards | Clean URLs |
+|------|-------------|------------|
+| GitHub Pages | Homepage only | Yes (via 404.html) |
+| Cloudflare Pages | Per-post | Yes (native) |
+| Other static hosts | Homepage only | Yes (via 404.html) |
 
 ## Network and data disclosure
 

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -95,6 +95,8 @@ describe("buildDocumentRecord", () => {
 		});
 
 		expect(record.coverImage).toBeUndefined();
+	});
+
 	it("includes references when provided", () => {
 		const record = buildDocumentRecord({
 			siteUri: "at://did:plc:abc123/site.standard.publication/self",

--- a/tests/viewer/helpers.test.ts
+++ b/tests/viewer/helpers.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect } from "vitest";
+import {
+  escapeHtml,
+  escapeAttr,
+  parseConfig,
+  findDocument,
+  buildMetaTags,
+  injectMetaTags,
+} from "../../viewer/functions/_lib/helpers.js";
+
+describe("escapeHtml", () => {
+  it("escapes angle brackets and ampersands", () => {
+    expect(escapeHtml('<script>alert("xss")</script>')).toBe(
+      '&lt;script&gt;alert("xss")&lt;/script&gt;'
+    );
+  });
+
+  it("passes through normal text", () => {
+    expect(escapeHtml("Hello World")).toBe("Hello World");
+  });
+
+  it("handles null/undefined", () => {
+    expect(escapeHtml(null)).toBe("null");
+    expect(escapeHtml(undefined)).toBe("undefined");
+  });
+});
+
+describe("escapeAttr", () => {
+  it("escapes double quotes", () => {
+    expect(escapeAttr('value with "quotes"')).toBe(
+      "value with &quot;quotes&quot;"
+    );
+  });
+});
+
+describe("parseConfig", () => {
+  const sampleHtml = `
+<script>
+const HANDLE = "alice.bsky.social";
+const PUBLICATION_RKEY = "self";
+const BASE_PATH = "/my-blog";
+</script>`;
+
+  it("extracts handle, rkey, and basePath", () => {
+    const config = parseConfig(sampleHtml);
+    expect(config.handle).toBe("alice.bsky.social");
+    expect(config.publicationRkey).toBe("self");
+    expect(config.basePath).toBe("/my-blog");
+  });
+
+  it("returns empty strings for missing values", () => {
+    const config = parseConfig("<html></html>");
+    expect(config.handle).toBe("");
+    expect(config.publicationRkey).toBe("");
+    expect(config.basePath).toBe("");
+  });
+
+  it("handles empty PUBLICATION_RKEY", () => {
+    const html = `const HANDLE = "alice.bsky.social";\nconst PUBLICATION_RKEY = "";`;
+    const config = parseConfig(html);
+    expect(config.publicationRkey).toBe("");
+  });
+});
+
+describe("findDocument", () => {
+  const docs = [
+    {
+      uri: "at://did:plc:abc/site.standard.document/post1",
+      value: { path: "/hello-world", title: "Hello", site: "at://did:plc:abc/site.standard.publication/self" },
+    },
+    {
+      uri: "at://did:plc:abc/site.standard.document/post2",
+      value: { path: "/second-post", title: "Second", site: "at://did:plc:abc/site.standard.publication/self" },
+    },
+    {
+      uri: "at://did:plc:abc/site.standard.document/orphan",
+      value: { path: "/orphan", title: "Orphan", site: "at://did:plc:abc/site.standard.publication/other" },
+    },
+  ];
+
+  it("finds by path", () => {
+    const doc = findDocument(docs, "/hello-world", null);
+    expect(doc?.value.title).toBe("Hello");
+  });
+
+  it("finds by rkey fallback", () => {
+    const doc = findDocument(docs, "/post2", null);
+    expect(doc?.value.title).toBe("Second");
+  });
+
+  it("returns null for no match", () => {
+    expect(findDocument(docs, "/nonexistent", null)).toBeNull();
+  });
+
+  it("filters by publication URI", () => {
+    const pubUri = "at://did:plc:abc/site.standard.publication/self";
+    const doc = findDocument(docs, "/orphan", pubUri);
+    expect(doc).toBeNull();
+  });
+
+  it("finds across all docs when no publication URI", () => {
+    const doc = findDocument(docs, "/orphan", null);
+    expect(doc?.value.title).toBe("Orphan");
+  });
+});
+
+describe("buildMetaTags", () => {
+  const base = {
+    publication: { name: "My Blog", description: "A blog about things" },
+    siteName: "My Blog",
+    siteUrl: "https://example.com/blog",
+    pdsUrl: "https://pds.example.com",
+    did: "did:plc:abc",
+  };
+
+  it("returns site-level tags for homepage", () => {
+    const tags = buildMetaTags({ ...base, routePath: "/", document: null });
+    expect(tags.title).toBe("My Blog");
+    expect(tags.ogType).toBe("website");
+    expect(tags.ogDescription).toBe("A blog about things");
+  });
+
+  it("returns post-level tags when document found", () => {
+    const doc = {
+      uri: "at://did:plc:abc/site.standard.document/post1",
+      value: { title: "My Post", description: "About stuff", path: "/my-post" },
+    };
+    const tags = buildMetaTags({ ...base, routePath: "/my-post", document: doc });
+    expect(tags.title).toBe("My Post \u2014 My Blog");
+    expect(tags.ogType).toBe("article");
+    expect(tags.ogUrl).toBe("https://example.com/blog/my-post");
+    expect(tags.twitterCard).toBe("summary");
+  });
+
+  it("includes og:image for posts with cover images", () => {
+    const doc = {
+      uri: "at://did:plc:abc/site.standard.document/post1",
+      value: {
+        title: "My Post",
+        description: "About stuff",
+        path: "/my-post",
+        coverImage: { ref: { $link: "bafyreiabc123" } },
+      },
+    };
+    const tags = buildMetaTags({ ...base, routePath: "/my-post", document: doc });
+    expect(tags.ogImage).toContain("com.atproto.sync.getBlob");
+    expect(tags.ogImage).toContain("bafyreiabc123");
+    expect(tags.twitterCard).toBe("summary_large_image");
+  });
+
+  it("returns site-level fallback for not-found routes", () => {
+    const tags = buildMetaTags({ ...base, routePath: "/nope", document: null });
+    expect(tags.title).toBe("My Blog");
+    expect(tags.ogType).toBe("website");
+  });
+});
+
+describe("injectMetaTags", () => {
+  const templateHtml = `<!DOCTYPE html>
+<html>
+<head>
+<title>Standard Site</title>
+<meta property="og:title" content="Standard Site">
+<meta property="og:description" content="">
+<meta property="og:type" content="website">
+<meta property="og:url" content="">
+<meta name="twitter:card" content="summary">
+</head>
+<body></body>
+</html>`;
+
+  it("replaces title and OG tags", () => {
+    const tags = {
+      title: "My Blog",
+      ogTitle: "My Blog",
+      ogDescription: "A great blog",
+      ogType: "website",
+      ogUrl: "https://example.com",
+      twitterCard: "summary",
+      ogImage: null,
+    };
+    const result = injectMetaTags(templateHtml, tags);
+    expect(result).toContain("<title>My Blog</title>");
+    expect(result).toContain('og:title" content="My Blog"');
+    expect(result).toContain('og:description" content="A great blog"');
+    expect(result).toContain('og:url" content="https://example.com"');
+  });
+
+  it("injects og:image when present", () => {
+    const tags = {
+      title: "Post",
+      ogTitle: "Post",
+      ogDescription: "",
+      ogType: "article",
+      ogUrl: "https://example.com/post",
+      twitterCard: "summary_large_image",
+      ogImage: "https://cdn.example.com/image.jpg",
+    };
+    const result = injectMetaTags(templateHtml, tags);
+    expect(result).toContain('og:image" content="https://cdn.example.com/image.jpg"');
+  });
+
+  it("does not add og:image when null", () => {
+    const tags = {
+      title: "Post",
+      ogTitle: "Post",
+      ogDescription: "",
+      ogType: "article",
+      ogUrl: "https://example.com",
+      twitterCard: "summary",
+      ogImage: null,
+    };
+    const result = injectMetaTags(templateHtml, tags);
+    expect(result).not.toContain("og:image");
+  });
+
+  it("escapes HTML in title", () => {
+    const tags = {
+      title: 'Post with <script> & "quotes"',
+      ogTitle: "Post",
+      ogDescription: "",
+      ogType: "article",
+      ogUrl: "",
+      twitterCard: "summary",
+      ogImage: null,
+    };
+    const result = injectMetaTags(templateHtml, tags);
+    expect(result).toContain("&lt;script&gt;");
+    expect(result).not.toContain("<script>");
+  });
+});

--- a/viewer/404.html
+++ b/viewer/404.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="UTF-8"></head>
+<body>
+<script>
+const BASE_PATH = "";
+const fullPath = window.location.pathname;
+const routePath = fullPath.slice(BASE_PATH.length) || "/";
+sessionStorage.setItem("redirectPath", routePath);
+window.location.replace(BASE_PATH + "/");
+</script>
+<noscript><p>JavaScript is required to view this site.</p></noscript>
+</body>
+</html>

--- a/viewer/functions/[[path]].js
+++ b/viewer/functions/[[path]].js
@@ -118,7 +118,11 @@ export async function onRequest(context) {
     const data = await getCachedSiteData(config, cacheKey, context.waitUntil.bind(context));
 
     const routePath = config.basePath
-      ? path.slice(config.basePath.length) || "/"
+      ? (path === config.basePath
+          ? "/"
+          : path.startsWith(config.basePath + "/")
+            ? path.slice(config.basePath.length) || "/"
+            : path)
       : path;
 
     const siteName = data.publication?.name || config.handle;

--- a/viewer/functions/[[path]].js
+++ b/viewer/functions/[[path]].js
@@ -1,0 +1,156 @@
+import {
+  parseConfig,
+  findDocument,
+  buildMetaTags,
+  injectMetaTags,
+} from "./_lib/helpers.js";
+
+const CACHE_TTL = 300; // 5 minutes
+
+async function resolveHandle(handle) {
+  const res = await fetch(
+    `https://bsky.social/xrpc/com.atproto.identity.resolveHandle?handle=${encodeURIComponent(handle)}`
+  );
+  if (!res.ok) throw new Error(`Could not resolve handle "${handle}"`);
+  return (await res.json()).did;
+}
+
+async function resolvePDS(did) {
+  let url;
+  if (did.startsWith("did:plc:")) {
+    url = `https://plc.directory/${encodeURIComponent(did)}`;
+  } else if (did.startsWith("did:web:")) {
+    const host = did.replace("did:web:", "").replaceAll(":", "/");
+    url = `https://${host}/.well-known/did.json`;
+  } else {
+    throw new Error(`Unsupported DID method: ${did}`);
+  }
+  const doc = await (await fetch(url)).json();
+  const svc = doc.service?.find(
+    (s) => s.id === "#atproto_pds" || s.type === "AtprotoPersonalDataServer"
+  );
+  if (!svc?.serviceEndpoint) throw new Error("No PDS found");
+  return svc.serviceEndpoint;
+}
+
+async function getPublication(pdsUrl, did, rkey) {
+  const res = await fetch(
+    `${pdsUrl}/xrpc/com.atproto.repo.getRecord?repo=${encodeURIComponent(did)}&collection=site.standard.publication&rkey=${encodeURIComponent(rkey)}`
+  );
+  if (!res.ok) return null;
+  return (await res.json()).value;
+}
+
+async function listAllDocuments(pdsUrl, did) {
+  const all = [];
+  let cursor;
+  do {
+    let url = `${pdsUrl}/xrpc/com.atproto.repo.listRecords?repo=${encodeURIComponent(did)}&collection=site.standard.document&limit=100`;
+    if (cursor) url += `&cursor=${encodeURIComponent(cursor)}`;
+    const res = await fetch(url);
+    if (!res.ok) throw new Error("Failed to list documents");
+    const data = await res.json();
+    for (const r of data.records) all.push(r);
+    cursor = data.cursor;
+  } while (cursor);
+  return all;
+}
+
+async function fetchSiteData(config) {
+  const did = await resolveHandle(config.handle);
+  const pdsUrl = await resolvePDS(did);
+  const publication = config.publicationRkey
+    ? await getPublication(pdsUrl, did, config.publicationRkey)
+    : null;
+  const publicationUri = config.publicationRkey
+    ? `at://${did}/site.standard.publication/${config.publicationRkey}`
+    : null;
+  const documents = await listAllDocuments(pdsUrl, did);
+  return { did, pdsUrl, publication, publicationUri, documents };
+}
+
+async function getCachedSiteData(config, cacheKey) {
+  const cache = caches.default;
+  const cacheUrl = new URL(`https://cache.internal/${cacheKey}`);
+
+  const cached = await cache.match(cacheUrl);
+  if (cached) {
+    return { data: await cached.json(), cache };
+  }
+
+  const data = await fetchSiteData(config);
+
+  const cacheResponse = new Response(JSON.stringify(data), {
+    headers: { "Cache-Control": `s-maxage=${CACHE_TTL}` },
+  });
+  // Don't await — write to cache in the background
+  cache.put(cacheUrl, cacheResponse);
+
+  return { data, cache };
+}
+
+export async function onRequest(context) {
+  const url = new URL(context.request.url);
+  const path = url.pathname;
+
+  // Pass through static assets and well-known files
+  if (
+    /\.(css|js|json|png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf|eot|xml|txt|webp|avif)$/.test(path) ||
+    path.startsWith("/.well-known/")
+  ) {
+    return context.next();
+  }
+
+  // Fetch static index.html
+  const assetUrl = new URL("/", url.origin);
+  const assetResponse = await context.env.ASSETS.fetch(assetUrl);
+  const html = await assetResponse.text();
+
+  // Parse config from HTML
+  const config = parseConfig(html);
+  if (!config.handle || config.handle === "your-handle.bsky.social") {
+    return new Response(html, {
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
+  }
+
+  try {
+    const cacheKey = `atproto-${config.handle}-${config.publicationRkey}`;
+    const { data } = await getCachedSiteData(config, cacheKey);
+
+    const routePath = config.basePath
+      ? path.slice(config.basePath.length) || "/"
+      : path;
+
+    const siteName = data.publication?.name || config.handle;
+    const siteUrl =
+      data.publication?.url || url.origin + config.basePath;
+
+    const doc = routePath !== "/" && routePath !== ""
+      ? findDocument(data.documents, routePath, data.publicationUri)
+      : null;
+
+    const tags = buildMetaTags({
+      routePath,
+      publication: data.publication,
+      document: doc,
+      siteName,
+      siteUrl,
+      pdsUrl: data.pdsUrl,
+      did: data.did,
+    });
+
+    const status =
+      routePath !== "/" && routePath !== "" && !doc ? 404 : 200;
+
+    return new Response(injectMetaTags(html, tags), {
+      status,
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
+  } catch {
+    // ATProto fetch failed — return unmodified static HTML
+    return new Response(html, {
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
+  }
+}

--- a/viewer/functions/_lib/helpers.js
+++ b/viewer/functions/_lib/helpers.js
@@ -1,0 +1,143 @@
+/**
+ * Escape HTML entities in text content.
+ */
+export function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+/**
+ * Escape HTML attribute values.
+ */
+export function escapeAttr(str) {
+  return String(str)
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+/**
+ * Parse HANDLE, PUBLICATION_RKEY, and BASE_PATH from viewer HTML.
+ */
+export function parseConfig(html) {
+  const handleMatch = html.match(/const HANDLE = "([^"]+)"/);
+  const rkeyMatch = html.match(/const PUBLICATION_RKEY = "([^"]*)"/);
+  const basePathMatch = html.match(/const BASE_PATH = "([^"]*)"/);
+  return {
+    handle: handleMatch?.[1] || "",
+    publicationRkey: rkeyMatch?.[1] || "",
+    basePath: basePathMatch?.[1] || "",
+  };
+}
+
+/**
+ * Find a document matching the given route path.
+ * Matches by document path field first, then falls back to rkey.
+ */
+export function findDocument(documents, path, publicationUri) {
+  const filtered = publicationUri
+    ? documents.filter((d) => d.value.site === publicationUri)
+    : documents;
+
+  const byPath = filtered.find((d) => d.value.path === path);
+  if (byPath) return byPath;
+
+  const segment = path.split("/").pop();
+  if (segment) {
+    const byRkey = filtered.find((d) => d.uri.split("/").pop() === segment);
+    if (byRkey) return byRkey;
+  }
+
+  return null;
+}
+
+/**
+ * Build OG meta tags object for a given route.
+ */
+export function buildMetaTags({ routePath, publication, document, siteName, siteUrl, pdsUrl, did }) {
+  if (routePath === "/" || routePath === "") {
+    return {
+      title: siteName,
+      ogTitle: siteName,
+      ogDescription: publication?.description || "",
+      ogType: "website",
+      ogUrl: siteUrl,
+      ogImage: null,
+      twitterCard: "summary",
+    };
+  }
+
+  if (document) {
+    const postTitle = document.value.title || "Untitled";
+    const postDesc = document.value.description || "";
+    let ogImage = null;
+    if (document.value.coverImage?.ref?.$link && pdsUrl && did) {
+      ogImage = `${pdsUrl}/xrpc/com.atproto.sync.getBlob?did=${encodeURIComponent(did)}&cid=${encodeURIComponent(document.value.coverImage.ref.$link)}`;
+    }
+    return {
+      title: `${postTitle} \u2014 ${siteName}`,
+      ogTitle: postTitle,
+      ogDescription: postDesc,
+      ogType: "article",
+      ogUrl: siteUrl + routePath,
+      ogImage,
+      twitterCard: ogImage ? "summary_large_image" : "summary",
+    };
+  }
+
+  // Not found — fallback to site-level tags
+  return {
+    title: siteName,
+    ogTitle: siteName,
+    ogDescription: publication?.description || "",
+    ogType: "website",
+    ogUrl: siteUrl,
+    ogImage: null,
+    twitterCard: "summary",
+  };
+}
+
+/**
+ * Inject OG meta tags into viewer HTML by replacing placeholder values.
+ */
+export function injectMetaTags(html, tags) {
+  let result = html;
+
+  // Replace <title>
+  result = result.replace(/<title>[^<]*<\/title>/, `<title>${escapeHtml(tags.title)}</title>`);
+
+  // Replace existing OG meta tags
+  result = result.replace(
+    /(<meta property="og:title" content=")[^"]*(">)/,
+    `$1${escapeAttr(tags.ogTitle)}$2`
+  );
+  result = result.replace(
+    /(<meta property="og:description" content=")[^"]*(">)/,
+    `$1${escapeAttr(tags.ogDescription || "")}$2`
+  );
+  result = result.replace(
+    /(<meta property="og:type" content=")[^"]*(">)/,
+    `$1${escapeAttr(tags.ogType || "website")}$2`
+  );
+  result = result.replace(
+    /(<meta property="og:url" content=")[^"]*(">)/,
+    `$1${escapeAttr(tags.ogUrl || "")}$2`
+  );
+  result = result.replace(
+    /(<meta name="twitter:card" content=")[^"]*(">)/,
+    `$1${escapeAttr(tags.twitterCard || "summary")}$2`
+  );
+
+  // Add og:image if present (insert after og:url line)
+  if (tags.ogImage) {
+    result = result.replace(
+      /(<meta property="og:url" content="[^"]*">)/,
+      `$1\n<meta property="og:image" content="${escapeAttr(tags.ogImage)}">`
+    );
+  }
+
+  return result;
+}

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -12,10 +12,16 @@
 <script>
 const HANDLE = "your-handle.bsky.social";
 const PUBLICATION_RKEY = "";
+const BASE_PATH = "";
 </script>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Loading...</title>
+<title>Standard Site</title>
+<meta property="og:title" content="Standard Site">
+<meta property="og:description" content="">
+<meta property="og:type" content="website">
+<meta property="og:url" content="">
+<meta name="twitter:card" content="summary">
 <link rel="stylesheet" href="custom.css">
 <style>
 :root {

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -818,7 +818,34 @@ function render() {
   }
 }
 
+// ── Client-side navigation ──────────────────────────────────────
+
+function navigateTo(path) {
+  history.pushState(null, "", path);
+  render();
+  window.scrollTo(0, 0);
+}
+
+document.getElementById("app").addEventListener("click", function(e) {
+  const link = e.target.closest("a");
+  if (!link) return;
+  const href = link.getAttribute("href");
+  if (!href) return;
+  // Only intercept internal links (same origin, starts with BASE_PATH)
+  if (href.startsWith(BASE_PATH + "/") || href === BASE_PATH + "/") {
+    e.preventDefault();
+    navigateTo(href);
+  }
+});
+
 async function init() {
+  // Recover from 404.html redirect (static host fallback)
+  const savedPath = sessionStorage.getItem("redirectPath");
+  if (savedPath) {
+    sessionStorage.removeItem("redirectPath");
+    history.replaceState(null, "", BASE_PATH + savedPath);
+  }
+
   if (HANDLE === "your-handle.bsky.social") {
     showSetupInstructions();
     return;
@@ -834,7 +861,7 @@ async function init() {
   }
 }
 
-window.addEventListener("hashchange", () => {
+window.addEventListener("popstate", () => {
   if (appState) render();
 });
 

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -827,6 +827,7 @@ function navigateTo(path) {
 }
 
 document.getElementById("app").addEventListener("click", function(e) {
+  if (!(e.target instanceof Element)) return;
   const link = e.target.closest("a");
   if (!link) return;
   const href = link.getAttribute("href");

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -304,7 +304,7 @@ const renderer = new marked.Renderer();
 renderer.link = function({ href, title, tokens }) {
   const safeHref = href || "";
   if (safeHref.startsWith("/") && !safeHref.includes("://")) {
-    href = "#" + safeHref;
+    href = BASE_PATH + safeHref;
   } else {
     href = safeHref;
   }
@@ -477,13 +477,14 @@ async function listAllDocuments(pdsUrl, did) {
 // ── Routing ────────────────────────────────────────────────────
 
 function getRoute() {
-  const hash = window.location.hash;
-  if (!hash || hash === "#" || hash === "#/") {
+  let path = window.location.pathname;
+  // Strip BASE_PATH prefix
+  if (BASE_PATH && path.startsWith(BASE_PATH)) {
+    path = path.slice(BASE_PATH.length);
+  }
+  if (!path || path === "/") {
     return { type: "home" };
   }
-  // Strip leading #
-  let path = hash.slice(1);
-  // Ensure leading /
   if (!path.startsWith("/")) path = "/" + path;
   return { type: "post", path };
 }
@@ -640,7 +641,7 @@ function showHomepage(publication, documents, did) {
     for (const doc of sorted) {
       const v = doc.value;
       const rkey = extractRkey(doc.uri);
-      const href = "#" + (v.path || "/" + rkey);
+      const href = BASE_PATH + (v.path || "/" + rkey);
       const title = v.title || "Untitled";
 
       const li = el("li", { className: "post-item" });
@@ -689,7 +690,7 @@ function showPost(publication, doc, did, documents) {
 
   // Nav
   const nav = el("nav", { className: "nav" });
-  const backLink = el("a", { href: "#/" });
+  const backLink = el("a", { href: BASE_PATH + "/" });
   backLink.innerHTML = DOMPurify.sanitize("&larr; " + escapeHtml(siteName));
   nav.appendChild(backLink);
   app.appendChild(nav);
@@ -730,7 +731,7 @@ function showPost(publication, doc, did, documents) {
     const ul = el("ul");
     for (const bl of backlinks) {
       const blRkey = extractRkey(bl.uri);
-      const href = "#" + (bl.value.path || "/" + blRkey);
+      const href = BASE_PATH + (bl.value.path || "/" + blRkey);
       const li = el("li");
       li.appendChild(el("a", { href }, bl.value.title || "Untitled"));
       ul.appendChild(li);
@@ -747,7 +748,7 @@ function showNotFound(path) {
   const app = clearApp();
 
   const nav = el("nav", { className: "nav" });
-  nav.appendChild(el("a", { href: "#/" }, "\u2190 Back"));
+  nav.appendChild(el("a", { href: BASE_PATH + "/" }, "\u2190 Back"));
   app.appendChild(nav);
 
   const errDiv = el("div", { className: "error" });

--- a/viewer/setup.sh
+++ b/viewer/setup.sh
@@ -103,7 +103,14 @@ derive_base_path() {
     return
   fi
   if command -v python3 &>/dev/null; then
-    python3 -c "from urllib.parse import urlparse; p=urlparse('$1').path.rstrip('/'); print('' if p == '/' else p)"
+    python3 - "$url" <<'PY'
+import sys
+from urllib.parse import urlparse
+
+url = sys.argv[1] if len(sys.argv) > 1 else ""
+p = urlparse(url).path.rstrip('/')
+print('' if p == '/' else p)
+PY
   else
     # Bash fallback
     local no_proto="${url#*://}"
@@ -234,28 +241,28 @@ info "Name: ${PUB_NAME:-"(none)"}"
 [ -n "$BASE_PATH" ] && info "Base path: ${BASE_PATH}"
 
 # Escape values for sed
-HANDLE_ESC=$(printf '%s' "$HANDLE" | sed 's/[&/\]/\\&/g')
-RKEY_ESC=$(printf '%s' "$RKEY" | sed 's/[&/\]/\\&/g')
-BASE_PATH_ESC=$(printf '%s' "$BASE_PATH" | sed 's/[&/\]/\\&/g')
-PUB_NAME_ESC=$(printf '%s' "$PUB_NAME" | sed 's/[&/\]/\\&/g')
-PUB_DESC_ESC=$(printf '%s' "$PUB_DESC" | sed 's/[&/\]/\\&/g')
-PUB_URL_ESC=$(printf '%s' "$PUB_URL" | sed 's/[&/\]/\\&/g')
+HANDLE_ESC=$(printf '%s' "$HANDLE" | sed 's/[&/\\]/\\&/g')
+RKEY_ESC=$(printf '%s' "$RKEY" | sed 's/[&/\\]/\\&/g')
+BASE_PATH_ESC=$(printf '%s' "$BASE_PATH" | sed 's/[&/\\]/\\&/g')
+PUB_NAME_ESC=$(printf '%s' "$PUB_NAME" | sed 's/[&/\\]/\\&/g')
+PUB_DESC_ESC=$(printf '%s' "$PUB_DESC" | sed 's/[&/\\]/\\&/g')
+PUB_URL_ESC=$(printf '%s' "$PUB_URL" | sed 's/[&/\\]/\\&/g')
 
 # Patch index.html
-sed "s/const HANDLE = \".*\";/const HANDLE = \"${HANDLE_ESC}\";/" index.html > index.html.tmp && mv index.html.tmp index.html
-sed "s/const PUBLICATION_RKEY = \".*\";/const PUBLICATION_RKEY = \"${RKEY_ESC}\";/" index.html > index.html.tmp && mv index.html.tmp index.html
-sed "s/const BASE_PATH = \".*\";/const BASE_PATH = \"${BASE_PATH_ESC}\";/" index.html > index.html.tmp && mv index.html.tmp index.html
+sed "s|const HANDLE = \".*\";|const HANDLE = \"${HANDLE_ESC}\";|" index.html > index.html.tmp && mv index.html.tmp index.html
+sed "s|const PUBLICATION_RKEY = \".*\";|const PUBLICATION_RKEY = \"${RKEY_ESC}\";|" index.html > index.html.tmp && mv index.html.tmp index.html
+sed "s|const BASE_PATH = \".*\";|const BASE_PATH = \"${BASE_PATH_ESC}\";|" index.html > index.html.tmp && mv index.html.tmp index.html
 info "Updated index.html (config)"
 
 # Patch OG meta tags
-sed "s/<title>[^<]*<\/title>/<title>${PUB_NAME_ESC}<\/title>/" index.html > index.html.tmp && mv index.html.tmp index.html
-sed "s/og:title\" content=\"[^\"]*\"/og:title\" content=\"${PUB_NAME_ESC}\"/" index.html > index.html.tmp && mv index.html.tmp index.html
-sed "s/og:description\" content=\"[^\"]*\"/og:description\" content=\"${PUB_DESC_ESC}\"/" index.html > index.html.tmp && mv index.html.tmp index.html
-sed "s/og:url\" content=\"[^\"]*\"/og:url\" content=\"${PUB_URL_ESC}\"/" index.html > index.html.tmp && mv index.html.tmp index.html
+sed "s|<title>[^<]*</title>|<title>${PUB_NAME_ESC}</title>|" index.html > index.html.tmp && mv index.html.tmp index.html
+sed "s|og:title\" content=\"[^\"]*\"|og:title\" content=\"${PUB_NAME_ESC}\"|" index.html > index.html.tmp && mv index.html.tmp index.html
+sed "s|og:description\" content=\"[^\"]*\"|og:description\" content=\"${PUB_DESC_ESC}\"|" index.html > index.html.tmp && mv index.html.tmp index.html
+sed "s|og:url\" content=\"[^\"]*\"|og:url\" content=\"${PUB_URL_ESC}\"|" index.html > index.html.tmp && mv index.html.tmp index.html
 info "Updated index.html (OG tags)"
 
 # Patch 404.html
-sed "s/const BASE_PATH = \".*\";/const BASE_PATH = \"${BASE_PATH_ESC}\";/" 404.html > 404.html.tmp && mv 404.html.tmp 404.html
+sed "s|const BASE_PATH = \".*\";|const BASE_PATH = \"${BASE_PATH_ESC}\";|" 404.html > 404.html.tmp && mv 404.html.tmp 404.html
 info "Updated 404.html"
 
 # Patch .well-known


### PR DESCRIPTION
## Summary

- Migrate viewer routing from hash (`#/path`) to History API (`/path`) with `BASE_PATH` support for subpath deployments
- Add Open Graph and Twitter Card meta tag placeholders to `index.html`, patched by `setup.sh` with publication metadata
- Add Cloudflare Pages Function (`functions/[[path]].js`) that injects per-post OG tags at the edge by fetching ATProto data
- Add `404.html` fallback for SPA routing on static hosts (GitHub Pages, etc.)
- Update `setup.sh` to download new files, fetch publication details, and patch OG tags + `BASE_PATH` in both `index.html` and `404.html`

## Changes

| File | What |
|------|------|
| `viewer/index.html` | BASE_PATH constant, OG meta placeholders, History API routing, pushState navigation, popstate listener, 404.html redirect recovery |
| `viewer/404.html` | New — SPA routing fallback for static hosts |
| `viewer/functions/[[path]].js` | New — Cloudflare Pages Function for per-post social cards |
| `viewer/functions/_lib/helpers.js` | New — Pure helper functions (escapeHtml, parseConfig, findDocument, buildMetaTags, injectMetaTags) |
| `viewer/setup.sh` | Publication detail fetching, BASE_PATH derivation, OG tag patching, 404.html patching, functions download |
| `tests/viewer/helpers.test.ts` | New — 20 tests for helper module |
| `tests/types.test.ts` | Fix pre-existing missing closing brace |
| `README.md` | Updated viewer features and deployment comparison table |

## Test plan

- [x] All 103 tests pass (9/9 suites)
- [x] Module exports verified via `node -e "import(...)"`
- [x] Zero remaining hash routing references in viewer
- [x] `setup.sh` syntax validated (`bash -n`)
- [x] Cloudflare Pages Function verified against official docs (catch-all routing, onRequest export, context.env.ASSETS, waitUntil for cache writes)
- [ ] Manual test: deploy to Cloudflare Pages and verify per-post OG tags
- [ ] Manual test: deploy to GitHub Pages and verify 404.html SPA routing

🤖 Generated with [Claude Code](https://claude.com/claude-code)